### PR TITLE
Update curve25519 and bulletproofs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2023-06-01
+      - image: polymeshassociation/rust:debian-nightly-2024-11-14
     environment:
       VERBOSE: "1"
     steps:
@@ -12,7 +12,7 @@ jobs:
           command: ./scripts/lint.sh
   build:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2023-06-01
+      - image: polymeshassociation/rust:debian-nightly-2024-11-14
     environment:
       VERBOSE: "1"
     steps:
@@ -35,7 +35,7 @@ jobs:
             - "./target"
   test:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2023-06-01
+      - image: polymeshassociation/rust:debian-nightly-2024-11-14
     environment:
       VERBOSE: "1"
     steps:
@@ -57,7 +57,7 @@ jobs:
             - "./target"
   build_wasm:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2023-06-01
+      - image: polymeshassociation/rust:debian-nightly-2024-11-14
     environment:
       VERBOSE: "1"
     steps:
@@ -85,7 +85,7 @@ jobs:
             - "./target"
   bench:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2023-06-01
+      - image: polymeshassociation/rust:debian-nightly-2024-11-14
     environment:
       VERBOSE: "1"
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "confidential_assets"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "Polymesh confidential assets."
 authors = [ "Polymesh Association" ]
 license-file = "LICENSE.txt"
+
+[patch.crates-io]
+bulletproofs = { version = "5.0.0", git = "https://github.com/PolymeshAssociation/bulletproofs", branch = "v5.0.0" }
+#bulletproofs = { path = "../bulletproofs/" }
 
 [dependencies]
 # SCALE
@@ -51,20 +55,18 @@ nightly = []
 # Discrete log Elgamal decryption.
 discrete_log = ["bincode", "itertools", "lazy_static"]
 
-# Backends
-u32_backend = []
-u64_backend = []
-avx2_backend = []
-simd_backend = []
-
-serde_all = ["serde", "curve25519-dalek/serde"]
+serde = [
+  "dep:serde",
+  "curve25519-dalek/serde",
+  "bulletproofs/serde",
+]
 
 alloc = ["rand_core/alloc", "rand/alloc", "curve25519-dalek/alloc"]
 
 no_std = []
 std = [
  # General and optional
- "serde_all",
+ "serde",
  # Crypto
  "rand_core/std",
  "rand/std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,6 @@ description = "Polymesh confidential assets."
 authors = [ "Polymesh Association" ]
 license-file = "LICENSE.txt"
 
-[patch.crates-io]
-bulletproofs = { version = "4.0.0", git = "https://github.com/PolymeshAssociation/bulletproofs", branch = "polymesh" }
-curve25519-dalek-ng = { git = "https://github.com/atouchet/curve25519-dalek-ng.git", branch = "simd" }
-
 [dependencies]
 # SCALE
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
@@ -25,13 +21,13 @@ log = "0.4"
 uuid = { version = "1.6", default-features = false }
 
 # Crypto
-sha3 = { version = "0.9", default-features = false, optional = true }
+sha3 = { version = "0.10", default-features = false, optional = true }
 
 rand_core = { version = "0.6", default-features = false}
 rand = { version = "0.8", default-features = false }
 
-curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, features = ["alloc"] }
-bulletproofs = { version = "4.0.0", default-features = false }
+curve25519-dalek = { version = "4", default-features = false, features = ["alloc"] }
+bulletproofs = { version = "5.0.0", default-features = false }
 
 merlin = { version = "3.0.0", default-features = false }
 
@@ -42,30 +38,30 @@ lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 # Crypto
-sha3 = { version = "0.9", default-features = false }
+sha3 = { version = "0.10", default-features = false }
 
 wasm-bindgen-test = { version = "0.3.10"}
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 criterion = { version = "0.3" }
 
 [features]
-default = ["std", "u64_backend", "rayon", "discrete_log"]
-nightly = ["curve25519-dalek/nightly"]
+default = ["std", "rayon", "discrete_log"]
+nightly = []
 
 # Discrete log Elgamal decryption.
 discrete_log = ["bincode", "itertools", "lazy_static"]
 
 # Backends
-u32_backend = ["curve25519-dalek/u32_backend", "bulletproofs/u32_backend"]
-u64_backend = ["curve25519-dalek/u64_backend", "bulletproofs/u64_backend"]
-avx2_backend = ["curve25519-dalek/avx2_backend", "bulletproofs/avx2_backend"]
-simd_backend = ["curve25519-dalek/simd_backend", "bulletproofs/simd_backend"]
+u32_backend = []
+u64_backend = []
+avx2_backend = []
+simd_backend = []
 
 serde_all = ["serde", "curve25519-dalek/serde"]
 
 alloc = ["rand_core/alloc", "rand/alloc", "curve25519-dalek/alloc"]
 
-no_std = ["u64_backend"]
+no_std = []
 std = [
  # General and optional
  "serde_all",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2024-11-14"
+components = [ "rustfmt" ]
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,0 @@
-[toolchain]
-channel = "nightly-2023-12-11"
-targets = [ "wasm32-unknown-unknown" ]
-components = [ "rustfmt" ]
-profile = "minimal"

--- a/src/codec_wrapper.rs
+++ b/src/codec_wrapper.rs
@@ -173,7 +173,7 @@ impl Decode for WrappedScalar {
     fn decode<I: Input>(input: &mut I) -> Result<Self, CodecError> {
         let s = <[u8; SCALAR_SIZE]>::decode(input)?;
 
-        let inner = Scalar::from_canonical_bytes(s)
+        let inner = Option::from(Scalar::from_canonical_bytes(s))
             .ok_or_else(|| CodecError::from("Non-canonical `Scalar`."))?;
         Ok(Self(inner))
     }

--- a/src/elgamal/mod.rs
+++ b/src/elgamal/mod.rs
@@ -190,11 +190,15 @@ impl CompressedCipherText {
     }
 
     pub fn x(&self) -> WrappedCompressedRistretto {
-        CompressedRistretto::from_slice(&self.0[0..32]).unwrap_or_default().into()
+        CompressedRistretto::from_slice(&self.0[0..32])
+            .unwrap_or_default()
+            .into()
     }
 
     pub fn y(&self) -> WrappedCompressedRistretto {
-        CompressedRistretto::from_slice(&self.0[32..64]).unwrap_or_default().into()
+        CompressedRistretto::from_slice(&self.0[32..64])
+            .unwrap_or_default()
+            .into()
     }
 
     pub fn decompress(&self) -> CipherText {

--- a/src/elgamal/mod.rs
+++ b/src/elgamal/mod.rs
@@ -176,8 +176,8 @@ impl CompressedCipherText {
 
     pub fn from_slice(bytes: &[u8]) -> Self {
         Self::from_points(
-            CompressedRistretto::from_slice(&bytes[0..32]),
-            CompressedRistretto::from_slice(&bytes[32..64]),
+            CompressedRistretto::from_slice(&bytes[0..32]).unwrap_or_default(),
+            CompressedRistretto::from_slice(&bytes[32..64]).unwrap_or_default(),
         )
     }
 
@@ -190,11 +190,11 @@ impl CompressedCipherText {
     }
 
     pub fn x(&self) -> WrappedCompressedRistretto {
-        CompressedRistretto::from_slice(&self.0[0..32]).into()
+        CompressedRistretto::from_slice(&self.0[0..32]).unwrap_or_default().into()
     }
 
     pub fn y(&self) -> WrappedCompressedRistretto {
-        CompressedRistretto::from_slice(&self.0[32..64]).into()
+        CompressedRistretto::from_slice(&self.0[32..64]).unwrap_or_default().into()
     }
 
     pub fn decompress(&self) -> CipherText {
@@ -396,7 +396,7 @@ impl ElgamalSecretKey {
         // value * h = Y - X / secret_key
         let value_h = *cipher_text.y - self.invert() * *cipher_text.x;
         // Brute force all possible values to find the one that matches value * h.
-        let mut result = Scalar::zero() * gens.B;
+        let mut result = Scalar::ZERO * gens.B;
         for v in 0..Balance::max_value() {
             if result == value_h {
                 return Ok(v);
@@ -478,7 +478,7 @@ impl ElgamalSecretKey {
 
         const CHUNK_SIZE: Balance = 64 * 1024; // Needs to be a power of two.
         const CHUNK_COUNT: Balance = Balance::max_value() / CHUNK_SIZE;
-        let mut tmp = Scalar::zero() * gens.B;
+        let mut tmp = Scalar::ZERO * gens.B;
         // Search the first chunk.
         for v in 0..CHUNK_SIZE {
             if tmp == value_h {
@@ -631,7 +631,7 @@ mod tests {
 
         // Test encrypting balance.
         let balance: Balance = 256;
-        let blinding = Scalar::zero();
+        let blinding = Scalar::ZERO;
         let balance_witness = CommitmentWitness {
             value: balance.into(),
             blinding,

--- a/src/proofs/encryption_proofs.rs
+++ b/src/proofs/encryption_proofs.rs
@@ -33,7 +33,7 @@ impl TryFrom<Scalar> for ZKPChallenge {
     type Error = Error;
 
     fn try_from(x: Scalar) -> Result<Self, Self::Error> {
-        ensure!(x != Scalar::zero(), Error::VerificationError);
+        ensure!(x != Scalar::ZERO, Error::VerificationError);
         Ok(ZKPChallenge { x })
     }
 }
@@ -334,7 +334,7 @@ mod tests {
             Error::CorrectnessFinalResponseVerificationError { check: 1 }
         );
 
-        let bad_final_response = CorrectnessFinalResponse::from(Scalar::one());
+        let bad_final_response = CorrectnessFinalResponse::from(Scalar::ONE);
         assert_err!(
             single_property_verifier(&verifier0, &(initial_message0, bad_final_response)),
             Error::CorrectnessFinalResponseVerificationError { check: 1 }

--- a/src/proofs/range_proof.rs
+++ b/src/proofs/range_proof.rs
@@ -25,7 +25,7 @@ impl InRangeProof {
     pub fn build<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let pc_gens = PedersenGens::default();
         let range = 32;
-        Self::prove(&pc_gens, 0, Scalar::one(), range, rng).expect("This shouldn't happen.")
+        Self::prove(&pc_gens, 0, Scalar::ONE, range, rng).expect("This shouldn't happen.")
     }
 
     fn bp_gens(len: usize) -> BulletproofGens {

--- a/tests/bad_public_key.rs
+++ b/tests/bad_public_key.rs
@@ -26,12 +26,12 @@ pub fn bad_public_key() {
 
     let gens = PedersenGens::default();
 
-    let refresh_blinding = Scalar::one();
+    let refresh_blinding = Scalar::ONE;
     let y_diff = *sender_init_balance.y - (refresh_blinding * gens.B_blinding);
 
     let mut transcript = Transcript::new(ENCRYPTION_PROOFS_LABEL);
 
-    let z = Scalar::zero(); //Scalar::random(&mut rng);
+    let z = Scalar::ZERO; //Scalar::random(&mut rng);
     let a = y_diff;
     let b = gens.B_blinding;
     let initial_message = CipherTextRefreshmentInitialMessage {

--- a/tests/bad_refreshment.rs
+++ b/tests/bad_refreshment.rs
@@ -147,7 +147,7 @@ pub fn bad_refreshment2() {
     );
     // Set `z` to zero:
     if let Some(proof) = &mut proof_gen.balance_refreshed_same_proof {
-        proof.1 .0 = Scalar::zero().into();
+        proof.1 .0 = Scalar::ZERO.into();
     }
     eprintln!(
         "-- refreshment proof: {:?}",


### PR DESCRIPTION
1. Switch to the official `curve25519-dalek` crate instead of the `*-ng` version.
2. Upgrade to `bulletproofs` v5 with some fixes (optional `serde` and downgrade `subtle`): https://github.com/PolymeshAssociation/bulletproofs/tree/v5.0.0
3. Remove the `*_backend` feature flags, they are not needed anymore.